### PR TITLE
"Remove dependency on range-v3 library"

### DIFF
--- a/include/isl/flatmap.hpp
+++ b/include/isl/flatmap.hpp
@@ -3,8 +3,6 @@
 
 #include <isl/isl.hpp>
 #include <isl/iterator.hpp>
-#include <range/v3/range.hpp>
-#include <range/v3/view.hpp>
 #include <utility>
 
 namespace isl


### PR DESCRIPTION
This commit removed the range-v3 library from the project and modified functions depending on it.

The use of filter from the range-v3 was replaced with regular for-loops and `if` conditional checks. The removal reduces dependencies, simplifies the code and also improves readability. Since range-v3 was no longer needed, it was removed from vcpkg.json.